### PR TITLE
removed  from Mask.componentWillReceiveProps

### DIFF
--- a/src/Mask.jsx
+++ b/src/Mask.jsx
@@ -58,7 +58,7 @@ export default class Mask extends Component {
       this.props.value !== nextProps.value ||
       this.props.defaultValue !== nextProps.defaultValue ||
       this.props.emptyChar !== nextProps.emptyChar) {
-      this.setValue(nextProps.value || nextProps.defaultValue, nextProps);
+      this.setValue(nextProps.value, nextProps);
     }
   }
 


### PR DESCRIPTION
This `||` causes a problem for controlled components, like that

``` jsx
<Mask id="postings" pattern="00" value={row.postings} onChange={this.handleChange(row)}>
```

If I have some value comes from state, say "1" and when remove it in input field, the exception is throw from `applyMaskToString()` because in `this.setValue(nextProps.value || nextProps.defaultValue)` - nextProps.value is `''` and nextProps.defaultValue is `undefined`.

`'' || undefined` gives `undefined` which is passed as value.
